### PR TITLE
add docs_link and docs_info to Task models and TaskManifest

### DIFF
--- a/schemas/manifest.py
+++ b/schemas/manifest.py
@@ -4,6 +4,7 @@ from typing import TypeVar
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import HttpUrl
 from pydantic import root_validator
 from pydantic import validator
 
@@ -37,6 +38,10 @@ class _TaskManifestBase(BaseModel):
             etc.
         args_schema:
             JSON Schema for task arguments
+        docs_info:
+            Additional information about the Task, coming from the docstring.
+        docs_link:
+            Link to Task docs.
     """
 
     name: str
@@ -45,6 +50,8 @@ class _TaskManifestBase(BaseModel):
     output_type: str
     meta: Optional[dict[str, Any]] = Field(default_factory=dict)
     args_schema: Optional[dict[str, Any]]
+    docs_info: Optional[str]
+    docs_link: Optional[HttpUrl]
 
 
 TaskManifestType = TypeVar("TaskManifestType", bound=_TaskManifestBase)

--- a/schemas/task.py
+++ b/schemas/task.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import HttpUrl
 from pydantic import validator
 
 from ._validators import valstr
@@ -41,6 +42,8 @@ class TaskUpdate(_TaskBase):
     version: Optional[str]
     args_schema: Optional[dict[str, Any]]
     args_schema_version: Optional[str]
+    docs_info: Optional[str]
+    docs_link: Optional[HttpUrl]
 
     # Validators
     _name = validator("name", allow_reuse=True)(valstr("name"))
@@ -73,6 +76,8 @@ class TaskRead(_TaskBase):
     version: Optional[str]
     args_schema: Optional[dict[str, Any]]
     args_schema_version: Optional[str]
+    docs_info: Optional[str]
+    docs_link: Optional[HttpUrl]
 
 
 class TaskCreate(_TaskBase):
@@ -84,6 +89,8 @@ class TaskCreate(_TaskBase):
     version: Optional[str]
     args_schema: Optional[dict[str, Any]]
     args_schema_version: Optional[str]
+    docs_info: Optional[str]
+    docs_link: Optional[HttpUrl]
 
     # Validators
     _name = validator("name", allow_reuse=True)(valstr("name"))

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -7,7 +7,6 @@ from schemas import TaskManifestV1
 
 
 def test_ManifestV1():
-
     task_without_args_schema = TaskManifestV1(
         name="Task A",
         executable="executable",
@@ -22,6 +21,15 @@ def test_ManifestV1():
         output_type="output_type",
         default_args={"arg": "val"},
         args_schema={"something": "else"},
+    )
+    task_with_docs_right_link = TaskManifestV1(
+        name="Task B",
+        executable="executable",
+        input_type="input_type",
+        output_type="output_type",
+        default_args={"arg": "val"},
+        args_schema={"something": "else"},
+        docs_link="http://www.example.org",
     )
 
     m = ManifestV1(
@@ -41,6 +49,24 @@ def test_ManifestV1():
         task_list=[task_with_args_schema],
     )
     debug(m)
+    m = ManifestV1(
+        manifest_version="1",
+        has_args_schemas=True,
+        task_list=[task_with_docs_right_link],
+    )
+    debug(m)
+
+    with pytest.raises(ValidationError) as e:
+        TaskManifestV1(
+            name="Task B",
+            executable="executable",
+            input_type="input_type",
+            output_type="output_type",
+            default_args={"arg": "val"},
+            args_schema={"something": "else"},
+            docs_link="htp://www.example.org",
+        )
+    debug(e.value)
 
     with pytest.raises(ValidationError) as e:
         m = ManifestV1(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -43,3 +43,16 @@ def test_task_create():
     # Missing arguments
     with pytest.raises(ValidationError):
         TaskCreate(name="task", source="source")
+
+    # Bad docs link
+    with pytest.raises(ValidationError):
+        TaskCreate(
+            name="task",
+            source="source",
+            command="command",
+            input_type="input_type",
+            output_type="output_type",
+            version="1.2.3",
+            owner="someone",
+            docs_link="htp://www.example.org",
+        )


### PR DESCRIPTION
closes #90 
* `docs_link` has type `Optional[HttpUrl]` and `docs_info` has type `Optional[str]`
* add `docs_link` and `docs_info` to `Task{Read,Create,Update}` 
* add `docs_link` and `docs_info` to `TaskManifestV1`
* add tests for `docs_link` url validation 